### PR TITLE
Update to rmsceme 0.5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 __pycache__/
+.idea
+poetry.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [tool.poetry]
 name = "rmc"
-version = "0.1.1"
+version = "0.2.0a0"
 description = "Convert to/from v6 .rm files from the reMarkable tablet"
 authors = ["Rick Lupton <mail@ricklupton.name>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.10"
-rmscene = ">=0.1.0, <0.3.0"
+rmscene = ">=0.5.0, <0.6.0"
 click = "^8.0"
 
 [tool.poetry.dev-dependencies]

--- a/src/rmc/__init__.py
+++ b/src/rmc/__init__.py
@@ -1,2 +1,2 @@
-from .exporters.svg import blocks_to_svg, rm_to_svg
+from .exporters.svg import tree_to_svg, rm_to_svg
 from .exporters.pdf import rm_to_pdf

--- a/src/rmc/cli.py
+++ b/src/rmc/cli.py
@@ -109,8 +109,8 @@ def convert_rm(filename: Path, to, fout):
             blocks_to_svg(blocks, fout)
         elif to == "pdf":
             buf = io.StringIO()
-            blocks = read_blocks(f)
-            blocks_to_svg(blocks, buf)
+            tree = read_tree(f)
+            tree_to_svg(tree, buf)
             buf.seek(0)
             svg_to_pdf(buf, fout)
         else:

--- a/src/rmc/cli.py
+++ b/src/rmc/cli.py
@@ -6,9 +6,8 @@ import io
 from pathlib import Path
 from contextlib import contextmanager
 import click
-from rmscene import read_blocks, write_blocks, TextFormat
-from rmscene.text import extract_text, simple_text_document
-from .exporters.svg import blocks_to_svg
+from rmscene import read_tree, read_blocks, write_blocks, simple_text_document
+from .exporters.svg import tree_to_svg
 from .exporters.pdf import svg_to_pdf
 from .exporters.markdown import print_text
 
@@ -105,8 +104,8 @@ def convert_rm(filename: Path, to, fout):
         elif to == "markdown":
             print_text(f, fout)
         elif to == "svg":
-            blocks = read_blocks(f)
-            blocks_to_svg(blocks, fout)
+            tree = read_tree(f)
+            tree_to_svg(tree, fout)
         elif to == "pdf":
             buf = io.StringIO()
             tree = read_tree(f)

--- a/src/rmc/exporters/markdown.py
+++ b/src/rmc/exporters/markdown.py
@@ -9,8 +9,11 @@ from rmscene.text import TextDocument
 def print_text(f, fout):
     tree = read_tree(f)
 
+    # Find out what anchor characters are used
+    anchor_ids = set(collect_anchor_ids(tree.root))
+
     if tree.root_text:
-        print_root_text(tree.root_text, fout)
+        print_root_text(tree.root_text, fout, anchor_ids)
 
     JOIN_TOLERANCE = 2
     print("\n\n# Highlights", file=fout)
@@ -27,16 +30,36 @@ def print_text(f, fout):
 def print_root_text(root_text: si.Text, fout, anchor_ids):
     doc = TextDocument.from_scene_item(root_text)
     for p in doc.contents:
-        line = str(p)
+        annotated_line = annotate_anchor_ids(anchor_ids,
+                                             str(p),
+                                             [char_id for s in p.contents for char_id in s.i])
         if p.style.value == si.ParagraphStyle.BULLET:
-            fout.write("- " + line)
+            fout.write("- " + annotated_line)
         elif p.style.value == si.ParagraphStyle.BULLET2:
-            fout.write("  + " + line)
+            fout.write("  + " + annotated_line)
         elif p.style.value == si.ParagraphStyle.BOLD:
-            fout.write("> " + line)
+            fout.write("> " + annotated_line)
         elif p.style.value == si.ParagraphStyle.HEADING:
-            fout.write("# " + line)
+            fout.write("# " + annotated_line)
         elif p.style.value == si.ParagraphStyle.PLAIN:
-            fout.write(line)
+            fout.write(annotated_line)
         else:
-            fout.write(("[unknown format %s] " % p.style.value) + line)
+            fout.write(("[unknown format %s] " % p.style.value) + annotated_line)
+
+
+def annotate_anchor_ids(anchor_ids, line, ids):
+    """Annotate appearances of `anchor_ids` in `line`."""
+    result = ""
+    for char, char_id in zip(line, ids):
+        if char_id in anchor_ids:
+            result += f"<<{char_id.part1},{char_id.part2}>>"
+        result += char
+    return result
+
+
+def collect_anchor_ids(item):
+    if isinstance(item, si.Group):
+        if item.anchor_id is not None:
+            yield item.anchor_id.value
+        for child in item.children.values():
+            yield from collect_anchor_ids(child)

--- a/src/rmc/exporters/markdown.py
+++ b/src/rmc/exporters/markdown.py
@@ -12,8 +12,19 @@ def print_text(f, fout):
     if tree.root_text:
         print_root_text(tree.root_text, fout)
 
+    JOIN_TOLERANCE = 2
+    print("\n\n# Highlights", file=fout)
+    last_pos = 0
+    for item in tree.walk():
+        if isinstance(item, si.GlyphRange):
+            if item.start > last_pos + JOIN_TOLERANCE:
+                print(file=fout)
+            print(">", item.text, file=fout)
+            last_pos = item.start + len(item.text)
+    print(file=fout)
 
-def print_root_text(root_text: si.Text, fout):
+
+def print_root_text(root_text: si.Text, fout, anchor_ids):
     doc = TextDocument.from_scene_item(root_text)
     for p in doc.contents:
         line = str(p)

--- a/src/rmc/exporters/markdown.py
+++ b/src/rmc/exporters/markdown.py
@@ -1,23 +1,31 @@
 """Export text content of rm files as Markdown."""
 
-from rmscene import TextFormat
-from rmscene.text import extract_text
+from rmscene import read_tree
+from rmscene import scene_items as si
 
-import logging
-
+from rmscene.text import TextDocument
 
 
 def print_text(f, fout):
-    for fmt, line in extract_text(f):
-        if fmt == TextFormat.BULLET:
-            print("- " + line, file=fout)
-        elif fmt == TextFormat.BULLET2:
-            print("  + " + line, file=fout)
-        elif fmt == TextFormat.BOLD:
-            print("> " + line, file=fout)
-        elif fmt == TextFormat.HEADING:
-            print("# " + line, file=fout)
-        elif fmt == TextFormat.PLAIN:
-            print(line, file=fout)
+    tree = read_tree(f)
+
+    if tree.root_text:
+        print_root_text(tree.root_text, fout)
+
+
+def print_root_text(root_text: si.Text, fout):
+    doc = TextDocument.from_scene_item(root_text)
+    for p in doc.contents:
+        line = str(p)
+        if p.style.value == si.ParagraphStyle.BULLET:
+            fout.write("- " + line)
+        elif p.style.value == si.ParagraphStyle.BULLET2:
+            fout.write("  + " + line)
+        elif p.style.value == si.ParagraphStyle.BOLD:
+            fout.write("> " + line)
+        elif p.style.value == si.ParagraphStyle.HEADING:
+            fout.write("# " + line)
+        elif p.style.value == si.ParagraphStyle.PLAIN:
+            fout.write(line)
         else:
-            print(("[unknown format %s] " % fmt) + line, file=fout)
+            fout.write(("[unknown format %s] " % p.style.value) + line)

--- a/src/rmc/exporters/pdf.py
+++ b/src/rmc/exporters/pdf.py
@@ -8,11 +8,7 @@ import logging
 from tempfile import NamedTemporaryFile
 from subprocess import check_call
 
-from rmscene import read_blocks
-from .svg import rm_to_svg, blocks_to_svg
-from .utils import (
-    run_command,
-)
+from .svg import rm_to_svg
 
 _logger = logging.getLogger(__name__)
 

--- a/src/rmc/exporters/svg.py
+++ b/src/rmc/exporters/svg.py
@@ -180,18 +180,22 @@ def draw_text(text: si.Text, output, anchor_pos):
     ''')
 
     y_offset = TEXT_TOP_Y
-    for fmt, line, ids in text.formatted_lines_with_ids():
-        y_offset += LINE_HEIGHTS[fmt]
+
+    doc = TextDocument.from_scene_item(text)
+    for p in doc.contents:
+        y_offset += LINE_HEIGHTS[p.style.value]
 
         xpos = text.pos_x
         ypos = text.pos_y + y_offset
-        cls = fmt.name.lower()
-        if line:
-            output.write(f'        <!-- Text line char_id: {ids[0]} -->\n')
-            output.write(f'        <text x="{xx(xpos)}" y="{yy(ypos)}" class="{cls}">{line.strip()}</text>\n')
+        cls = p.style.value.name.lower()
+        if str(p):
+            # TODO: this doesn't take into account the CrdtStr.properties (font-weight/font-style)
+            output.write(f'        <!-- Text line char_id: {p.start_id} -->\n')
+            output.write(f'        <text x="{xpos}" y="{ypos}" class="{cls}">{str(p).strip()}</text>\n')
 
         # Save y-coordinates of potential anchors
-        for k in ids:
-            anchor_pos[k] = ypos
+        for subp in p.contents:
+            for k in subp.i:
+                anchor_pos[k] = ypos
 
     output.write('    </g>\n')

--- a/src/rmc/exporters/svg.py
+++ b/src/rmc/exporters/svg.py
@@ -6,6 +6,7 @@ https://github.com/chemag/maxio .
 
 import logging
 import string
+from pathlib import Path
 
 from rmscene import read_tree, SceneTree, CrdtId
 from rmscene import scene_items as si
@@ -73,13 +74,24 @@ def rm_to_svg(rm_path, svg_path):
         tree_to_svg(tree, outfile)
 
 
-def tree_to_svg(tree: SceneTree, output):
+def read_template_svg(template_path: Path) -> str:
+    lines = template_path.read_text().splitlines()
+    return "\n".join(lines[2:-1])
+
+
+def tree_to_svg(tree: SceneTree, output, include_template=None):
     """Convert Blocks to SVG."""
 
     # add svg header
     output.write(SVG_HEADER.substitute(width=PAGE_WIDTH_PT,
                                        height=PAGE_HEIGHT_PT,
                                        viewbox=f"0 0 {PAGE_WIDTH_PT} {PAGE_HEIGHT_PT}") + "\n")
+
+    if include_template is not None:
+        template = read_template_svg(include_template)
+        output.write(f'    <g id="template" style="display:inline" transform="scale({SCALE})">\n')
+        output.write(template)
+        output.write('    </g>\n')
 
     output.write(f'    <g id="p1" style="display:inline" transform="translate({X_SHIFT},0)">\n')
     output.write('        <filter id="blurMe"><feGaussianBlur in="SourceGraphic" stdDeviation="10" /></filter>\n')


### PR DESCRIPTION
To update from [rmscene](https://github.com/ricklupton/rmscene) 0.2.0 to 0.3.0 the main modification is to use the SceneTree API instead of iterating the blocks. This was already done in https://github.com/ricklupton/rmc/pull/5.

Then the biggest modification of [rmscene](https://github.com/ricklupton/rmscene) from 0.3.0 to 0.5.0 is the removal of methods from `scene_items.Text` object. The intended replacement is `text.TextDocument`. This impacted the `markdown.print_text` function and the `svg.draw_text`.

Rick Lupton also added some features in the PR 5, that i decided to keep in this pr:
- [new "tree" output format](https://github.com/Seb-sti1/rmc/pull/1/commits/8fda77170205c56c76205f53327c72faa799f380), to print the rm structure in the terminal
- show [highlights](https://github.com/Seb-sti1/rmc/pull/1/commits/3c6ae0105fad4ffc526f4e236009f235c811a39e) and [anchor locations](https://github.com/Seb-sti1/rmc/pull/1/commits/272e0f58883b3c32351f32f0297403f95e264b9d) in markdown export 
- [scale svg down to 72 DPI](https://github.com/Seb-sti1/rmc/pull/1/commits/4d6c777ae9505848501ae12cdd435516a5664cd7)
- [tree_to_svg support adding a background template](https://github.com/Seb-sti1/rmc/pull/1/commits/23fd77772a561c7aae55b6f597d7210a60f027fc)

<br/><br/>

_I originally started this PR using the commits from https://github.com/ricklupton/rmc/pull/5._